### PR TITLE
Disable React import ESLint rule due to React 18 upgrade

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,9 @@
 module.exports = {
-  extends: ["@calblueprint/eslint-config-react"],
+  extends: ['@calblueprint/eslint-config-react'],
+  rules: {
+    // Add any custom rules here
+    // Disable the rule that requires React to be in scope -- we don't need this with React 18
+    'react/react-in-jsx-scope': 'off',
+    'react/jsx-uses-react': 'off',
+  },
 };


### PR DESCRIPTION
## What's new in this PR? :speech_balloon:
Disabled the rule that requires React to be imported, since this is no longer needed since our upga to React 18 in #7 (the Big change).

### :cloud: :cloud: Documentation :cloud: :cloud:

_Describe your feature & code in detail, so that future developers know how to handle it_

This is the recommended approach, based on this guide (& others): https://bobbyhadz.com/blog/react-must-be-in-scope-when-using-jsx#update-your-eslint-configuration-if-you-use-react-version-17

### :zap: Testing :zap:

_List all manual tests done/new unit tests you have implemented_
n/a

### Screenshots :calling:

_Required for visual changes - please CC Esther (leexesther) below if adding screenshots!_

**Before:**
<img width="831" alt="image" src="https://user-images.githubusercontent.com/21160510/219900246-9e625399-5600-411d-b182-4f62ed3e5102.png">


**After:**
<img width="548" alt="image" src="https://user-images.githubusercontent.com/21160510/219900258-00dee240-7323-4327-beb6-cec0ef2b9d19.png">

## :seedling: Related PRs :seedling:

_Describe any other PRs that might affect/depend on yours_

**_Optional - any related PRs you're waiting on, or PRs that will conflict, etc_**

### :space_invader: Any notable bugs you encountered or are still having trouple with? :space_invader:
n/a
### :boom: TODO:
n/a

CC: @davidqing6432
