### PR TITLE
Fix prop type errors in shared components

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -13,7 +13,11 @@ const styles = StyleSheet.create({
   },
 });
 
-function BackButton(handleFunction: () => void) {
+type BackButtonProps = {
+  handleFunction: () => void;
+};
+
+function BackButton({ handleFunction }: BackButtonProps) {
   return (
     <Pressable onPress={() => handleFunction()} style={styles.back}>
       <Icon type="chevron_left" />

--- a/src/components/LabeledTextInput.tsx
+++ b/src/components/LabeledTextInput.tsx
@@ -1,4 +1,4 @@
-import { Text, TextInput, StyleSheet, TextStyle } from 'react-native';
+import { StyleSheet, Text, TextInput, TextStyle } from 'react-native';
 import globalStyles from '../globalStyles';
 
 const styles = StyleSheet.create({
@@ -13,11 +13,17 @@ const styles = StyleSheet.create({
   },
 });
 
-function LabeledTextInput(
-  label: string,
-  containerStyle: TextStyle,
-  placeholder: string,
-) {
+type LabeledTextInputProps = {
+  label: string;
+  containerStyle: TextStyle;
+  placeholder: string;
+};
+
+function LabeledTextInput({
+  label,
+  containerStyle,
+  placeholder,
+}: LabeledTextInputProps) {
   return (
     <>
       <Text style={globalStyles.body1}>{label}</Text>

--- a/src/components/RectButton.tsx
+++ b/src/components/RectButton.tsx
@@ -25,13 +25,21 @@ const styles = StyleSheet.create({
   },
 });
 
-function RectButton(
-  text: string,
-  onPress: (event: GestureResponderEvent) => void,
-  buttonStyle: ViewStyle,
-  textStyle: TextStyle,
-  disable?: boolean,
-) {
+type RectButtonProps = {
+  text: string;
+  onPress: (event: GestureResponderEvent) => void;
+  buttonStyle: ViewStyle;
+  textStyle: TextStyle;
+  disable?: boolean;
+};
+
+function RectButton({
+  text,
+  onPress,
+  buttonStyle,
+  textStyle,
+  disable,
+}: RectButtonProps) {
   return (
     <Pressable
       disabled={disable}


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## :tada: What's new in this PR :tada:

### :cloud: :cloud: Description :cloud: :cloud:
[//]: # "REQUIRED - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

Fixed an issue introduced in #19 where all uses of `LabeledTextInput`, `RectButton`, and `BackButton` resulted in a TypeScript error (see screenshots below).

The issue is that the props were not specified as an object, but instead as separate function parameters. This PR fixes this issue by:
- Creating a type for the props of each component
- Updating the function definitions for these components to be an object of that type

**Resulting Typescript errors**
![image](https://user-images.githubusercontent.com/21160510/222320726-37bdc069-1e7e-49b7-81c1-b071d5b59bd3.png)
<img width="769" alt="image" src="https://user-images.githubusercontent.com/21160510/222320836-3bf9e44f-21bb-4506-b2d8-49429733f1bb.png">


### Screenshots :calling:
[//]: # "REQUIRED for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy! If you are making changes here, please CC: @leexesther at the bottom."

n/a -- everything should work again now!

## :zap: How to review :zap:
[//]: # 'REQUIRED - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'

Everything should run & display properly again! Prior to this fix, things probably don't work.

## :seedling: Next steps :seedling:
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."
n/a

## Relevant Links :link:
n/a

### Online sources :information_source:
[//]: # 'Optional - copy links to any tutorials or documentation that was useful to you when working on this PR'
n/a


### Related PRs :raised_hands:
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

Fixes the regression introduced in #19 


[//]: # 'This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
CC: @davidqing6432
